### PR TITLE
Don't crash if there is a DNS hiccup.

### DIFF
--- a/GravatarApi.php
+++ b/GravatarApi.php
@@ -79,22 +79,22 @@ class GravatarApi
 
     /**
      * Checks if a gravatar exists for the email. It does this by checking for the presence of 404 in the header
-     * returned. Will return false if fsockopen fails, for example when the hostname cannot be resolved.
+     * returned. Will return null if fsockopen fails, for example when the hostname cannot be resolved.
      *
      * @param string $email
-     * @return Boolean
+     * @return Boolean|null Boolean if we could connect, null if no connection to gravatar.com
      */
     public function exists($email)
     {
         $path = $this->getUrl($email, null, null, '404');
 
-        if ($sock = @fsockopen('gravatar.com', 80, $errorNo, $error)) {
-            fputs($sock, "HEAD " . $path . " HTTP/1.0\r\n\r\n");
-            $header = fgets($sock, 128);
-            fclose($sock);
-            return strpos($header, '404') ? false : true;
+        if (!$sock = @fsockopen('gravatar.com', 80, $errorNo, $error)) {
+            return null;
         }
 
-        return false;
+        fputs($sock, "HEAD " . $path . " HTTP/1.0\r\n\r\n");
+        $header = fgets($sock, 128);
+        fclose($sock);
+        return strpos($header, '404') ? false : true;
     }
 }


### PR DESCRIPTION
If there is a problem resolving gravatar.com, exists was throwing "sockopen(): php_network_getaddresses: getaddrinfo failed: No such host is known".  Now just return false.
