### PR TITLE
Fix secure gravatar option testing

### DIFF
--- a/GravatarApi.php
+++ b/GravatarApi.php
@@ -70,7 +70,7 @@ class GravatarApi
             'd' => $default ?: $this->defaults['default'],
         );
 
-        if (null === $secure) {
+        if (null == $secure) {
             $secure = $this->defaults['secure'];
         }
 


### PR DESCRIPTION
The default secure option from config.yml is not recognized.

It seems to be caused by the strict php comparison which doesn't work.
