### PR TITLE
Remove deprecated Twig_SimpleFunction

### DIFF
--- a/Twig/GravatarExtension.php
+++ b/Twig/GravatarExtension.php
@@ -26,11 +26,11 @@ class GravatarExtension extends \Twig_Extension implements GravatarHelperInterfa
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('gravatar', array($this, 'getUrl')),
-            new \Twig_SimpleFunction('gravatar_hash', array($this, 'getUrlForHash')),
-            new \Twig_SimpleFunction('gravatar_profile', array($this, 'getProfileUrl')),
-            new \Twig_SimpleFunction('gravatar_profile_hash', array($this, 'getProfileUrlForHash')),
-            new \Twig_SimpleFunction('gravatar_exists', array($this, 'exists')),
+            new \Twig_Function('gravatar', array($this, 'getUrl')),
+            new \Twig_Function('gravatar_hash', array($this, 'getUrlForHash')),
+            new \Twig_Function('gravatar_profile', array($this, 'getProfileUrl')),
+            new \Twig_Function('gravatar_profile_hash', array($this, 'getProfileUrlForHash')),
+            new \Twig_Function('gravatar_exists', array($this, 'exists')),
         );
     }
 


### PR DESCRIPTION
Using Symfony 3.x and Twig 2.x.
As explained in the doc: http://twig.sensiolabs.org/doc/deprecated.html#functions
It can be replaced directly by Twig_Function

Possible to create a Sf3/Twig2 branch for this ?