### PR TITLE
Default all URLs to https:// by default  #44

### DIFF
--- a/GravatarApi.php
+++ b/GravatarApi.php
@@ -21,7 +21,7 @@ class GravatarApi
         'size'    => 80,
         'rating'  => 'g',
         'default' => null,
-        'secure'  => false,
+        'secure'  => true,
     );
 
     /**
@@ -45,7 +45,7 @@ class GravatarApi
      *
      * @return string
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = null)
+    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true)
     {
         $hash = md5(strtolower(trim($email)));
 
@@ -63,7 +63,7 @@ class GravatarApi
      *
      * @return string
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = null)
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true)
     {
         $map = array(
             's' => $size    ?: $this->defaults['size'],
@@ -71,7 +71,7 @@ class GravatarApi
             'd' => $default ?: $this->defaults['default'],
         );
 
-        $secure = $secure ?: $this->defaults['secure'];
+        $secure = isset($secure) ? $secure : $this->defaults['secure'];
 
         return ($secure ? 'https://secure' : 'http://www').'.gravatar.com/avatar/'.$hash.'?'.http_build_query(array_filter($map));
     }
@@ -84,7 +84,7 @@ class GravatarApi
      *
      * @return string
      */
-    public function getProfileUrl($email, $secure = null)
+    public function getProfileUrl($email, $secure = true)
     {
         $hash = md5(strtolower(trim($email)));
 
@@ -99,7 +99,7 @@ class GravatarApi
      *
      * @return string
      */
-    public function getProfileUrlForHash($hash, $secure = null)
+    public function getProfileUrlForHash($hash, $secure = true)
     {
         $secure = $secure ?: $this->defaults['secure'];
 

--- a/Templating/Helper/GravatarHelper.php
+++ b/Templating/Helper/GravatarHelper.php
@@ -38,7 +38,7 @@ class GravatarHelper extends Helper implements GravatarHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = null)
+    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true)
     {
         return $this->api->getUrl($email, $size, $rating, $default, $this->isSecure($secure));
     }
@@ -46,7 +46,7 @@ class GravatarHelper extends Helper implements GravatarHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = null)
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true)
     {
         return $this->api->getUrlForHash($hash, $size, $rating, $default, $this->isSecure($secure));
     }
@@ -54,7 +54,7 @@ class GravatarHelper extends Helper implements GravatarHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrl($email, $secure = null)
+    public function getProfileUrl($email, $secure = true)
     {
         return $this->api->getProfileUrl($email, $this->isSecure($secure));
     }
@@ -62,7 +62,7 @@ class GravatarHelper extends Helper implements GravatarHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrlForHash($hash, $secure = null)
+    public function getProfileUrlForHash($hash, $secure = true)
     {
         return $this->api->getProfileUrlForHash($hash, $this->isSecure($secure));
     }
@@ -92,7 +92,7 @@ class GravatarHelper extends Helper implements GravatarHelperInterface
      *
      * @return Boolean
      */
-    protected function isSecure($preset = null)
+    protected function isSecure($preset = true)
     {
         if (null !== $preset) {
             return !!$preset;

--- a/Templating/Helper/GravatarHelperInterface.php
+++ b/Templating/Helper/GravatarHelperInterface.php
@@ -15,7 +15,7 @@ interface GravatarHelperInterface
      *
      * @return string
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = null);
+    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true);
 
     /**
      * Returns a url for a gravatar for a given hash.
@@ -28,7 +28,7 @@ interface GravatarHelperInterface
      *
      * @return string
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = null);
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true);
 
     /**
      * Returns a url for a gravatar profile.
@@ -38,7 +38,7 @@ interface GravatarHelperInterface
      *
      * @return string
      */
-    public function getProfileUrl($email, $secure = null);
+    public function getProfileUrl($email, $secure = true);
 
     /**
      * Returns a url for a gravatar profile, for the given hash.
@@ -48,7 +48,7 @@ interface GravatarHelperInterface
      *
      * @return string
      */
-    public function getProfileUrlForHash($hash, $secure = null);
+    public function getProfileUrlForHash($hash, $secure = true);
 
     /**
      * Returns true if a avatar could be found for the email.

--- a/Tests/GravatarApiTest.php
+++ b/Tests/GravatarApiTest.php
@@ -9,7 +9,13 @@ class GravatarApiTest extends \PHPUnit_Framework_TestCase
     public function testGravatarUrlWithDefaultOptions()
     {
         $api = new GravatarApi();
-        $this->assertEquals('http://www.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g', $api->getUrl('henrik@bearwoods.dk   '));
+        $this->assertEquals('https://secure.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g', $api->getUrl('henrik@bearwoods.dk   '));
+    }
+
+    public function testGravatarUrlWithDefaultOptionsNotSecure()
+    {
+        $api = new GravatarApi();
+        $this->assertEquals('http://www.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g', $api->getUrl('henrik@bearwoods.dk', null, null, null, false));
     }
 
     public function testGravatarSecureUrlWithDefaultOptions()
@@ -21,7 +27,7 @@ class GravatarApiTest extends \PHPUnit_Framework_TestCase
     public function testGravatarUrlWithDefaultImage()
     {
         $api = new GravatarApi();
-        $this->assertEquals('http://www.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g&d=mm', $api->getUrl('henrik@bearwoods.dk', 80, 'g', 'mm'));
+        $this->assertEquals('https://secure.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g&d=mm', $api->getUrl('henrik@bearwoods.dk', 80, 'g', 'mm'));
     }
 
     public function testGravatarSecureProfileUrlWithDefaultOptions()
@@ -33,7 +39,7 @@ class GravatarApiTest extends \PHPUnit_Framework_TestCase
     public function testGravatarProfileUrlWithDefaultImage()
     {
         $api = new GravatarApi();
-        $this->assertEquals('http://www.gravatar.com/0aa61df8e35327ac3b3bc666525e0bee', $api->getProfileUrl('henrik@bearwoods.dk'));
+        $this->assertEquals('https://secure.gravatar.com/0aa61df8e35327ac3b3bc666525e0bee', $api->getProfileUrl('henrik@bearwoods.dk'));
     }
 
     public function testGravatarInitializedWithOptions()
@@ -43,7 +49,7 @@ class GravatarApiTest extends \PHPUnit_Framework_TestCase
             'default' => 'mm',
         ));
 
-        $this->assertEquals('http://www.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=20&r=g&d=mm', $api->getUrl('henrik@bearwoods.dk'));
+        $this->assertEquals('https://secure.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=20&r=g&d=mm', $api->getUrl('henrik@bearwoods.dk'));
     }
 
     public function testGravatarExists()

--- a/Tests/Templating/Helper/GravatarHelperTest.php
+++ b/Tests/Templating/Helper/GravatarHelperTest.php
@@ -16,20 +16,7 @@ class GravatarHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUrlReturnsTheCorrectUrl()
     {
-        $this->assertEquals('http://www.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g', $this->helper->getUrl('henrik@bearwoods.dk'));
-    }
-
-    public function testGetUrlReturnsTheCorrectSecureUrl()
-    {
-        $this->assertEquals(
-            'https://secure.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g',
-            $this->helper->getUrl('henrik@bearwoods.dk', null, null, null, true)
-        );
-    }
-
-    public function testGetProfileUrlReturnsTheCorrectUrl()
-    {
-        $this->assertEquals('http://www.gravatar.com/0aa61df8e35327ac3b3bc666525e0bee', $this->helper->getProfileUrl('henrik@bearwoods.dk'));
+        $this->assertEquals('https://secure.gravatar.com/avatar/0aa61df8e35327ac3b3bc666525e0bee?s=80&r=g', $this->helper->getUrl('henrik@bearwoods.dk'));
     }
 
     public function testGetProfileUrlReturnsTheCorrectSecureUrl()
@@ -43,7 +30,7 @@ class GravatarHelperTest extends \PHPUnit_Framework_TestCase
     public function testGetProfileUrlForHashReturnsTheCorrectUrl()
     {
         $this->assertEquals(
-            'http://www.gravatar.com/0aa61df8e35327ac3b3bc666525e0bee',
+            'https://secure.gravatar.com/0aa61df8e35327ac3b3bc666525e0bee',
             $this->helper->getProfileUrlForHash('0aa61df8e35327ac3b3bc666525e0bee')
         );
     }

--- a/Twig/GravatarExtension.php
+++ b/Twig/GravatarExtension.php
@@ -37,7 +37,7 @@ class GravatarExtension extends \Twig_Extension implements GravatarHelperInterfa
     /**
      * {@inheritdoc}
      */
-    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = null)
+    public function getUrl($email, $size = null, $rating = null, $default = null, $secure = true)
     {
         return $this->baseHelper->getUrl($email, $size, $rating, $default, $secure);
     }
@@ -45,7 +45,7 @@ class GravatarExtension extends \Twig_Extension implements GravatarHelperInterfa
     /**
      * {@inheritdoc}
      */
-    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = null)
+    public function getUrlForHash($hash, $size = null, $rating = null, $default = null, $secure = true)
     {
         return $this->baseHelper->getUrlForHash($hash, $size, $rating, $default, $secure);
     }
@@ -53,7 +53,7 @@ class GravatarExtension extends \Twig_Extension implements GravatarHelperInterfa
     /*
      * {@inheritdoc}
      */
-    public function getProfileUrl($email, $secure = null)
+    public function getProfileUrl($email, $secure = true)
     {
         return $this->baseHelper->getProfileUrl($email, $secure);
     }
@@ -61,7 +61,7 @@ class GravatarExtension extends \Twig_Extension implements GravatarHelperInterfa
     /**
      * {@inheritdoc}
      */
-    public function getProfileUrlForHash($hash, $secure = null)
+    public function getProfileUrlForHash($hash, $secure = true)
     {
         return $this->baseHelper->getProfileUrlForHash($hash, $secure);
     }


### PR DESCRIPTION
Generating non-secure URLs is still possible, by passing in $secure = false.
