### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - nightly
-  - hhvm
-
-env:
-  global:
-    - PATH="$HOME/.composer/vendor/bin:$PATH"
 
 sudo: false
 
@@ -20,28 +15,22 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
+      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev
+      env: SYMFONY_VERSION=2.8.*
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
+      env: SYMFONY_VERSION="3.3.*"
+    - php: 5.6
+      env: SYMFONY_VERSION="3.4.*"
+    - php: 7.1
+      env: SYMFONY_VERSION="4.0.*"
   allow_failures:
     - php: nightly
-    - php: hhvm
-    - env: SYMFONY_VERSION=2.8.*@dev
-    - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 before_script:
   - composer selfupdate
-  - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
-  - composer global require phpunit/phpunit:4.* --no-update
-  - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
-
-script: make test

--- a/Tests/GravatarApiTest.php
+++ b/Tests/GravatarApiTest.php
@@ -3,8 +3,9 @@
 namespace Ornicar\GravatarBundle\Tests;
 
 use Ornicar\GravatarBundle\GravatarApi;
+use PHPUnit\Framework\TestCase;
 
-class GravatarApiTest extends \PHPUnit_Framework_TestCase
+class GravatarApiTest extends TestCase
 {
     public function testGravatarUrlWithDefaultOptions()
     {

--- a/Tests/Templating/Helper/GravatarHelperTest.php
+++ b/Tests/Templating/Helper/GravatarHelperTest.php
@@ -4,8 +4,9 @@ namespace Ornicar\GravatarBundle\Tests\Templating\Helper;
 
 use Ornicar\GravatarBundle\GravatarApi;
 use Ornicar\GravatarBundle\Templating\Helper\GravatarHelper;
+use PHPUnit\Framework\TestCase;
 
-class GravatarHelperTest extends \PHPUnit_Framework_TestCase
+class GravatarHelperTest extends TestCase
 {
     protected $helper;
 

--- a/Tests/Twig/GravatarExtensionTest.php
+++ b/Tests/Twig/GravatarExtensionTest.php
@@ -4,8 +4,9 @@ namespace Ornicar\GravatarBundle\Tests\Twig;
 
 use Ornicar\GravatarBundle\Templating\Helper\GravatarHelperInterface;
 use Ornicar\GravatarBundle\Twig\GravatarExtension;
+use PHPUnit\Framework\TestCase;
 
-class GravatarExtensionTest extends \PHPUnit_Framework_TestCase
+class GravatarExtensionTest extends TestCase
 {
     /**
      * @var GravatarHelperInterface
@@ -23,7 +24,7 @@ class GravatarExtensionTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Twig_Extension cannot be found');
         }
 
-        $this->helper = $this->getMock('Ornicar\GravatarBundle\Templating\Helper\GravatarHelperInterface');
+        $this->helper = $this->createMock('Ornicar\GravatarBundle\Templating\Helper\GravatarHelperInterface');
         $this->extension = new GravatarExtension($this->helper);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle" : "~3.0|~2.0"
+        "symfony/framework-bundle" : "~4.0|~3.0|~2.0"
     },
     "require-dev": {
         "twig/extensions": "1.0.*",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle" : "~4.0|~3.0|~2.0"
+        "symfony/framework-bundle" : "~4.0|~3.0|~2.0",
+        "symfony/templating": "~4.0|~3.0|~2.0"
     },
     "require-dev": {
         "twig/extensions": "1.0.*",


### PR DESCRIPTION
- PHP 5.5 and Symfony 2.3 do not receive security updates anymore, so removed them
- Added PHP 7.1 and Symfony 3.3, 3.4 and 4.0 
- There is [no need](https://github.com/composer/composer/issues/4884#issuecomment-195229989) for the github oauth token anymore.
- Travis [delivers](https://docs.travis-ci.com/user/languages/php/#Default-Build-Script) a version of phpunit for us
- Also cherry-picked the Symfony 4 upgrade commit of @tehplague, otherwise the Symfony 4 test will fail ofc.

Hopefully that was enough to fix the build :slightly_smiling_face: 