### PR TITLE
Remove deprecated target-dir composer usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,10 @@
         "twig/twig": "<1.12"
     },
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Ornicar\\GravatarBundle\\": ""
         }
     },
-    "target-dir" : "Ornicar/GravatarBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"


### PR DESCRIPTION
Ref: https://getcomposer.org/doc/04-schema.md#target-dir

See also: https://github.com/maglnet/ComposerRequireChecker/issues/55

Could you please make a new release after the merge? Thanks! :+1: 